### PR TITLE
Pagy nav stays at bottom of page, and redesigned filter form

### DIFF
--- a/app/assets/stylesheets/pages/_discover-page.scss
+++ b/app/assets/stylesheets/pages/_discover-page.scss
@@ -9,16 +9,17 @@
   margin: 0 auto;
 }
 
-.discover-title-filter-container {
+.discover-title-container {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
+  padding-bottom: 20px;
 }
 
 .discover-title {
-  font-family: $sub-header-font;
+  font-family: $main-header-font;
   font-size: 48px;
-  font-weight: 400;
+  font-weight: 600;
   color: $white;
   margin: 0px;
 }
@@ -26,57 +27,23 @@
 .filter-form-with {
   display: flex;
   align-items: center;
+  justify-content: center;
 }
 
 .filter-form-group {
-  display: flex;
-  border: none;
-  padding: 0px;
+  display: contents;
 }
 
-.filter-form-label {
-  color: $white;
-  font-size: 16px;
-  font-family: $body-font;
-  padding: 0px 6px;
-  padding-top: 8px;
-}
-
-.filter-label-spacer,
-.filter-legend-spacer {
+.filter-label-spacer {
   margin: 0px 10px;
 }
 
-.filter-form-legend,
-.filter-form-category {
+.filter-form-label {
   color: $white;
   font-size: 20px;
   font-family: $sub-header-font;
   display: contents;
   font-weight: 500;
-}
-
-.filter-form-check-input {
-  -webkit-appearance: none;
-  appearance: none;
-  background-color: #fff;
-  margin: 0;
-  font: inherit;
-  color: currentColor;
-  width: 0.75em;
-  height: 0.75em;
-  border: 0.1em solid currentColor;
-  border-color: $light-gray;
-  border-radius: 50%;
-  display: grid;
-  place-content: center;
-  transition: 0.1s;
-  display: inline-block;
-}
-
-.filter-form-check-input:checked {
-  background-color: $green;
-  border-color: $green;
 }
 
 .filter-form-button {
@@ -95,6 +62,7 @@
   background-origin: content-box;
   box-shadow: 4px 4px 8px rgba(0, 0, 0, 0.1);
   transition: all 0.25s ease;
+  margin-left: 20px;
 }
 
 .filter-form-button:hover {
@@ -110,8 +78,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 20px;
-  margin-bottom: 20px;
-  padding: 20px 0px;
+  padding: 20px 0px 100px 0px;
 }
 
 .filter-no-videos {
@@ -121,7 +88,7 @@
 }
 
 .pagy-nav {
-  position: relative;
+  position: absolute;
   bottom: 0;
   left: 0;
   width: 100%;
@@ -129,7 +96,7 @@
   z-index: 1;
   display: flex;
   justify-content: center;
-  padding: 20px;
+  padding: 20px 0px;
 }
 
 .pagy-nav a {

--- a/app/javascript/controllers/filter_form_controller.js
+++ b/app/javascript/controllers/filter_form_controller.js
@@ -5,59 +5,34 @@ export default class extends Controller {
 
   connect() {
     this.toggleSortDirectionField();
-    this.lastClickedRadioButton = null;
-    this.lastClickedSortByRadioButton = null;
-    this.setupRadioButtons();
-  }
-
-  setupRadioButtons() {
-    const sortByRadioButtons = this.element.querySelectorAll("[name='sort_by']");
-    const sortDirectionRadioButtons = this.element.querySelectorAll("[name='sort_direction']");
-
-    sortByRadioButtons.forEach(sortByRadioButton => {
-      sortByRadioButton.addEventListener('click', () => {
-        if (sortByRadioButton === this.lastClickedSortByRadioButton) {
-          this.lastClickedSortByRadioButton.checked = false;
-          this.lastClickedSortByRadioButton = null;
-        } else {
-          this.lastClickedSortByRadioButton = sortByRadioButton;
-        }
-      });
-    });
-
-    sortDirectionRadioButtons.forEach(sortDirectionRadioButton => {
-      sortDirectionRadioButton.addEventListener('click', () => {
-        if (sortDirectionRadioButton === this.lastClickedSortDirectionRadioButton) {
-          this.lastClickedSortDirectionRadioButton.checked = false;
-          this.lastClickedSortDirectionRadioButton = null;
-        } else {
-          this.lastClickedSortDirectionRadioButton = sortDirectionRadioButton;
-        }
-      });
-    });
   }
 
   toggleSortDirectionField() {
-    const checkedRadioButton = this.element.querySelector("[name='sort_by']:checked");
-    if (!checkedRadioButton) return;
+    const sortBySelect = this.element.querySelector("[name='sort_by']");
+    const sortDirectionSelect = this.sortDirectionFieldTarget.querySelector('select');
 
-    const sortBy = checkedRadioButton.value;
-    const sortDirectionLabels = this.sortDirectionFieldTarget.querySelectorAll('label');
+    sortBySelect.addEventListener('change', () => {
+      const sortBy = sortBySelect.value;
 
-    if (sortBy === "date") {
-      sortDirectionLabels[0].innerHTML = `
-        <input type="radio" name="sort_direction" value="desc" class="filter-form-check-input" ${this.element.querySelector("[name='sort_direction']:checked") == 'desc' ? 'checked' : ''}> Newest
-      `;
-      sortDirectionLabels[1].innerHTML = `
-        <input type="radio" name="sort_direction" value="asc" class="filter-form-check-input" ${this.element.querySelector("[name='sort_direction']:checked") == 'asc' ? 'checked' : ''}> Oldest
-      `;
-    } else {
-      sortDirectionLabels[0].innerHTML = `
-        <input type="radio" name="sort_direction" value="desc" class="filter-form-check-input" ${this.element.querySelector("[name='sort_direction']:checked") == 'desc' ? 'checked' : ''}> Highest
-      `;
-      sortDirectionLabels[1].innerHTML = `
-        <input type="radio" name="sort_direction" value="asc" class="filter-form-check-input" ${this.element.querySelector("[name='sort_direction']:checked") == 'asc' ? 'checked' : ''}> Lowest
-      `;
-    }
+      // Clear existing options
+      sortDirectionSelect.innerHTML = '';
+
+      if (sortBy === "date") {
+        // Add options for date sorting
+        sortDirectionSelect.innerHTML += `
+          <option value="desc">Newest</option>
+          <option value="asc">Oldest</option>
+        `;
+      } else {
+        // Add options for other sorting types
+        sortDirectionSelect.innerHTML += `
+          <option value="desc">Highest</option>
+          <option value="asc">Lowest</option>
+        `;
+      }
+    });
+
+    // Trigger the change event initially to set initial options
+    sortBySelect.dispatchEvent(new Event('change'));
   }
 }

--- a/app/views/pages/discover.html.erb
+++ b/app/views/pages/discover.html.erb
@@ -6,57 +6,35 @@
 
 <div class="discover-page">
   <div class="discover-page-container">
-    <div class="discover-title-filter-container">
+    <div class="discover-title-container">
       <h1 class="discover-title">Discover</h1>
+    </div>
 
-      <div data-controller="filter-form">
-        <%= form_with(url: filter_pages_path, method: "get", id: "filterForm", class: "filter-form-with") do |form| %>
+    <div data-controller="filter-form">
+      <%= form_with(url: filter_pages_path, method: "get", id: "filterForm", class: "filter-form-with") do |form| %>
+        <div class="filter-label-spacer">
+          <%= form.label :category, "Category", class: "filter-form-label" %>
+        </div>
+        <%= form.select :category, options_for_select([["All", "all"], ["Art & Photography", "art & photography"], ["Business", "business"],
+        ["Crafts", "crafts"], ["Fashion", "fashion"], ["Gaming", "gaming"], ["Gardening", "gardening"], ["Health & Fitness", "health & fitness"],
+        ["Music", "music"], ["Sports", "sports"], ["Technology", "technology"]], selected: @category), class: "filter-form-select" %>
+
+        <div class="filter-form-group">
           <div class="filter-label-spacer">
-            <%= form.label :category, "Category", class: "filter-form-category" %>
+            <%= form.label :sort_by, "Sort By", class: "filter-form-label" %>
           </div>
-          <%= form.select :category, options_for_select([["All", "all"], ["Art & Photography", "art & photography"], ["Business", "business"],
-          ["Crafts", "crafts"], ["Fashion", "fashion"], ["Gaming", "gaming"], ["Gardening", "gardening"], ["Health & Fitness", "health & fitness"],
-          ["Music", "music"], ["Sports", "sports"], ["Technology", "technology"]], selected: @category), class: "filter-form-select" %>
+          <%= form.select :sort_by, options_for_select([["Views", "views"], ["Rating", "rating"], ["Date", "date"]], selected: @sort_by), class: "filter-form-select", data: { action: "change->filter-form#toggleSortDirectionField" } %>
+        </div>
 
-          <div>
-            <fieldset class="filter-form-group">
-              <div class="filter-legend-spacer">
-                <h6 class="filter-form-legend">Sort By:</h6>
-              </div>
-              <label class="filter-form-label">
-                <%= form.radio_button :sort_by, "views", checked: @sort_by == "views", class: "filter-form-check-input", data: { action: "change->filter-form#toggleSortDirectionField" } %>
-                Views
-              </label>
-              <label class="filter-form-label">
-                <%= form.radio_button :sort_by, "rating", checked: @sort_by == "rating", class: "filter-form-check-input", data: { action: "change->filter-form#toggleSortDirectionField" } %>
-                Rating
-              </label>
-              <label class="filter-form-label">
-                <%= form.radio_button :sort_by, "date", checked: @sort_by == "date", class: "filter-form-check-input", data: { action: "change->filter-form#toggleSortDirectionField" } %>
-                Date
-              </label>
-            </fieldset>
+        <div id="sortDirectionField" data-filter-form-target="sortDirectionField" class="filter-form-group">
+          <div class="filter-label-spacer">
+            <%= form.label :sort_direction, "Sort Direction", class: "filter-form-label" %>
           </div>
+            <%= form.select :sort_direction, options_for_select([["Highest", "desc"], ["Lowest", "asc"]], selected: @sort_direction), class: "filter-form-select" %>
+        </div>
 
-          <div id="sortDirectionField" data-filter-form-target="sortDirectionField">
-            <fieldset class="filter-form-group">
-              <div class="filter-legend-spacer">
-                <h6 class="filter-form-legend">Sort Direction:</h6>
-              </div>
-              <label class="filter-form-label">
-                <%= form.radio_button :sort_direction, "desc", checked: @sort_direction == "desc", class: "filter-form-check-input" %>
-                Highest
-              </label>
-              <label class="filter-form-label">
-                <%= form.radio_button :sort_direction, "asc", checked: @sort_direction == "asc", class: "filter-form-check-input" %>
-                Lowest
-              </label>
-            </fieldset>
-          </div>
-
-          <%= form.submit "Filter", class: "filter-form-button" %>
-        <% end %>
-      </div>
+        <%= form.submit "Filter", class: "filter-form-button" %>
+      <% end %>
     </div>
 
     <div class="video-card-container-discover">


### PR DESCRIPTION
- Pagy nav stays at bottom of page, and redesigned filter form
- Filter form now only uses form.selects no checkboxes
- Think about using select2-rails gem to help design selects